### PR TITLE
Exception handling if server non-responsive, prompt for quit during a flight

### DIFF
--- a/BushDiversTracker/BushDiversTracker.csproj
+++ b/BushDiversTracker/BushDiversTracker.csproj
@@ -9,9 +9,9 @@
     <Product>Bush Tracker</Product>
     <Authors>Bush Divers</Authors>
     <StartupObject></StartupObject>
-    <Version>1.0.1</Version>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
+    <Version>1.0.2.0</Version>
+    <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <FileVersion>1.0.2.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/BushDiversTracker/MainWindow.xaml
+++ b/BushDiversTracker/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:BushDiversTracker"
         mc:Ignorable="d"
         SizeToContent="WidthAndHeight"
-        Title="Bush Tracker" Background="White"
+        Title="Bush Tracker" Background="White" Closing="Window_Closing"
         >
     <Grid Width="755">
         <Grid.ColumnDefinitions>

--- a/BushDiversTracker/MainWindow.xaml.cs
+++ b/BushDiversTracker/MainWindow.xaml.cs
@@ -708,6 +708,29 @@ namespace BushDiversTracker
             UpdateDispatchWeight();
         }
 
+        private async void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            if (bReady)
+            {
+                if (MessageBox.Show("A flight is currently in progress. You will need to restart your flight at a later time.\n\nAre you sure you wish to quit?", "Cancel current flight?", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                {
+                    e.Cancel = true;
+
+                    await StopTracking();
+                    if (!bReady || MessageBox.Show("There was an error cancelling your flight. If you continue you will need to cancel your dispatch via the web.\n\nQuit anyway?", "Quit?", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                    {
+                        bReady = false;
+                        ((Window)sender).Close();
+                    }
+                }
+                else
+                    e.Cancel = true;
+            }
+
+            if (!e.Cancel)
+                CloseConnection();
+        }
+
         #endregion
 
 
@@ -855,7 +878,7 @@ namespace BushDiversTracker
         /// <summary>
         /// Cancels the tracking and progress of a flight
         /// </summary>
-        private async void StopTracking()
+        private async Task StopTracking()
         {
             ClearVariables();
             lblDistance.Visibility = Visibility.Hidden;

--- a/BushDiversTracker/MainWindow.xaml.cs
+++ b/BushDiversTracker/MainWindow.xaml.cs
@@ -235,15 +235,14 @@ namespace BushDiversTracker
                 try
                 {
                     simConnect.RequestDataOnSimObjectType(DAT_REQUESTS.REQUEST_1, DEFINITIONS.Struct1, 0, SIMCONNECT_SIMOBJECT_TYPE.USER);
-                    return;
                 }
                 catch (COMException ex)
                 {
                     Console.WriteLine(ex.Message);
-                    return;
                 }
             }
-            OpenConnection();
+            else
+                OpenConnection();
         }
 
         /// <summary>
@@ -660,6 +659,8 @@ namespace BushDiversTracker
         {
             lblStart.Visibility = Visibility.Visible;
             btnStart.IsEnabled = false;
+
+            // Todo, tidy this up
             if (flag)
             {
                 MessageBox.Show("Your engine(s) must be off before starting", "Bush Tracker", MessageBoxButton.OK, MessageBoxImage.Exclamation);
@@ -670,6 +671,10 @@ namespace BushDiversTracker
 
             bFlightTracking = true;
             lblErrorText.Visibility = Visibility.Hidden;
+            timer.Stop();
+            // Might still get a double-fire if the dispatch is ready to send or even if the timer has ticked but response yet to be received - "shouldn't" be an issue
+            Timer_Tick(null, null);
+            timer.Start();
         }
 
         private async void btnSubmit_Click(object sender, RoutedEventArgs e)

--- a/BushDiversTracker/MainWindow.xaml.cs
+++ b/BushDiversTracker/MainWindow.xaml.cs
@@ -614,7 +614,10 @@ namespace BushDiversTracker
                 simConnect.Dispose();
                 simConnect = null;
             }
-            this.timer.Stop();
+
+            if (timer != null)
+                timer.Stop();
+
             elConnection.Fill = Brushes.Red;
             elConnection.Stroke = Brushes.Red;
             btnConnect.IsEnabled = true;

--- a/BushDiversTracker/Services/APIService.cs
+++ b/BushDiversTracker/Services/APIService.cs
@@ -59,6 +59,9 @@ namespace BushDiversTracker.Services
             else if (res.StatusCode == HttpStatusCode.Unauthorized)
             {
                 var msg = "Unauthorised";
+                // Basic check
+                if (!System.Text.RegularExpressions.Regex.IsMatch(Properties.Settings.Default.Key, @"^\d+\|.{40}.*$"))
+                    msg += " - API key does not match expected format";
                 throw new Exception(msg);
             }
             else

--- a/BushDiversTracker/Services/APIService.cs
+++ b/BushDiversTracker/Services/APIService.cs
@@ -17,6 +17,13 @@ namespace BushDiversTracker.Services
         //protected string baseUrl = "http://localhost:8000/api";
         HttpClient _http = new HttpClient();
 
+        public APIService()
+        {
+            _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            var thisAssembly = System.Windows.Application.ResourceAssembly.GetName();
+            _http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(thisAssembly.Name, thisAssembly.Version.ToString()));
+        }
+
         /// <summary>
         /// Gets dispatch cargo/pax data
         /// </summary>

--- a/BushDiversTracker/Services/APIService.cs
+++ b/BushDiversTracker/Services/APIService.cs
@@ -30,8 +30,6 @@ namespace BushDiversTracker.Services
         /// <returns>Collection of cargo</returns>
         public async Task<ICollection<DispatchCargo>> GetDispatchCargoAsync()
         {
-            AddHeaders();
-            _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             HttpResponseMessage res = await _http.GetAsync($"{baseUrl}/dispatch/cargo");
             if (res.StatusCode == HttpStatusCode.OK)
             {
@@ -56,8 +54,9 @@ namespace BushDiversTracker.Services
         /// <returns>Dispatch information</returns>
         public async Task<Dispatch> GetDispatchInfoAsync()
         {
-            AddHeaders();
-            _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            // First 'dispatch' call should update auth details
+            AddAuthHeaders();
+
             HttpResponseMessage res = await _http.GetAsync($"{baseUrl}/dispatch");
             if (res.StatusCode == HttpStatusCode.OK)
             {
@@ -86,7 +85,6 @@ namespace BushDiversTracker.Services
         /// <returns>New location feedback</returns>
         public async Task<NewLocationResponse> PostNewLocationAsync(NewLocationRequest newLocation)
         {
-            AddHeaders();
             HttpResponseMessage res = await _http.PostAsJsonAsync($"{baseUrl}/pirep/destination", newLocation);
             if (res.StatusCode == HttpStatusCode.OK)
             {
@@ -112,7 +110,6 @@ namespace BushDiversTracker.Services
         /// <returns>true of logged successfully</returns>
         public async Task<bool> PostFlightLogAsync(FlightLog flightLog)
         {
-            AddHeaders();
             HttpResponseMessage res = await _http.PostAsJsonAsync($"{baseUrl}/log", flightLog);
             if (res.StatusCode == HttpStatusCode.Created)
             {
@@ -133,7 +130,6 @@ namespace BushDiversTracker.Services
         /// <returns>true if submission was successful</returns>
         public async Task<bool> PostPirepAsync(Pirep pirep)
         {
-            AddHeaders();
             HttpResponseMessage res = await _http.PostAsJsonAsync($"{baseUrl}/pirep/submit", pirep);
             if (res.StatusCode == HttpStatusCode.OK)
             {
@@ -153,8 +149,6 @@ namespace BushDiversTracker.Services
         /// <returns>true if successful</returns>
         public async Task<bool> CancelTrackingAsync()
         {
-            AddHeaders();
-            _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             HttpResponseMessage res = await _http.GetAsync($"{baseUrl}/pirep/reset");
             if (res.StatusCode == HttpStatusCode.OK)
             {
@@ -175,7 +169,6 @@ namespace BushDiversTracker.Services
         /// <returns>true if successful</returns>
         public async Task<bool> PostPirepStatusAsync(PirepStatus pirepStatus)
         {
-            AddHeaders();
             HttpResponseMessage res = await _http.PostAsJsonAsync($"{baseUrl}/pirep/status", pirepStatus);
             if (res.StatusCode == HttpStatusCode.OK)
             {
@@ -204,7 +197,7 @@ namespace BushDiversTracker.Services
         /// <summary>
         /// Adds default headers to a request
         /// </summary>
-        protected void AddHeaders()
+        protected void AddAuthHeaders()
         {
             _http.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Bearer", Properties.Settings.Default.Key);


### PR DESCRIPTION
Resolves #6, will no longer crash if the server is momentarily unavailable.

May need to further modify FlightLog handling if server requires the historic log data.